### PR TITLE
Add Game Over Visual and Restart Game Trigger

### DIFF
--- a/scenes/Gameplay.gd
+++ b/scenes/Gameplay.gd
@@ -10,23 +10,42 @@ var secret_score:int = 0
 func _ready():
 	projectile_pool.init(self)
 	turret_generator.init(self)
-	
+
+	$Announcement.text = ""
+
 	$SecretScore.hide()
-	
+	$Announcement.hide()
+
 	$Player1.connect("create_turret", turret_generator, "_on_create_turret")
 	$Player2.connect("create_turret", turret_generator, "_on_create_turret")
 	$Player1.connect("kill", self, "_on_kill")
 	$Player2.connect("kill", self, "_on_kill")
 	$Player1.connect("upgrade_consumed", self, "_on_upgrade_consumed")
 	$Player2.connect("upgrade_consumed", self, "_on_upgrade_consumed")
-	
-	
+
 func _on_kill(player_number:int):
-	print_debug("game is over, player " + str(player_number) + " was defeated")
-	#TODO: Implement game over logic here.
+	_game_over(player_number)
 
 func _on_upgrade_consumed():
 	secret_score += 1
 	$SecretScore.text = str(secret_score)
 	if secret_score > 20:
 		$SecretScore.show()
+
+#############
+# GAME OVER #
+#############
+func _game_over(player_number_lost:int):
+	print_debug("game is over, player " + str(player_number_lost) + " was defeated")
+	$UpgradeProgress.pause_mode = Node.PAUSE_MODE_STOP
+	if $Announcement.visible == false:
+		$Announcement.text = _get_game_over_text(player_number_lost)
+		$Announcement.show()
+
+func _get_game_over_text(player_number_lost:int):
+	# Get remaining player number out of 2 players.
+	var player_number_won = 1
+	if player_number_lost == 1:
+		player_number_won = 2
+
+	return "Game Over\nPlayer " + str(player_number_won) + " Wins!"

--- a/scenes/Gameplay.gd
+++ b/scenes/Gameplay.gd
@@ -37,8 +37,9 @@ func _on_upgrade_consumed():
 #############
 func _game_over(player_number_lost:int):
 	print_debug("game is over, player " + str(player_number_lost) + " was defeated")
-	$UpgradeProgress.pause_mode = Node.PAUSE_MODE_STOP
-	if $Announcement.visible == false:
+	if !$Announcement.visible:
+		get_tree().paused = true
+		$GameOverToResetDelay.start()
 		$Announcement.text = _get_game_over_text(player_number_lost)
 		$Announcement.show()
 
@@ -48,4 +49,17 @@ func _get_game_over_text(player_number_lost:int):
 	if player_number_lost == 1:
 		player_number_won = 2
 
-	return "Game Over\nPlayer " + str(player_number_won) + " Wins!"
+	return "Player " + str(player_number_won) + " Wins!"
+
+
+func _on_GameOverToResetDelay_timeout():
+	# Show prompt to restart game.
+	var textToAppend = ""
+
+	if $Announcement.text != "":
+		textToAppend = "\n"
+
+	textToAppend += "Press Any Key to Restart"
+
+	$Announcement.text += textToAppend
+	$Announcement.show()

--- a/scenes/Gameplay.tscn
+++ b/scenes/Gameplay.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://hud/UpgradeProgress.tscn" type="PackedScene" id=2]
 [ext_resource path="res://scenes/Gameplay.gd" type="Script" id=3]
 [ext_resource path="res://hud/PlayerHealthBar.tscn" type="PackedScene" id=4]
 [ext_resource path="res://hud/NextUpgradeTracker.tscn" type="PackedScene" id=5]
+[ext_resource path="res://scenes/RestartGameControl.gd" type="Script" id=6]
 
 [node name="Gameplay" type="Node"]
 script = ExtResource( 3 )
@@ -61,4 +62,9 @@ pause_mode = 2
 wait_time = 1.5
 one_shot = true
 
+[node name="RestartGameControl" type="Node" parent="."]
+pause_mode = 2
+script = ExtResource( 6 )
+
 [connection signal="timeout" from="GameOverToResetDelay" to="." method="_on_GameOverToResetDelay_timeout"]
+[connection signal="timeout" from="GameOverToResetDelay" to="RestartGameControl" method="_on_GameOverToResetDelay_timeout"]

--- a/scenes/Gameplay.tscn
+++ b/scenes/Gameplay.tscn
@@ -14,6 +14,7 @@ margin_left = 452.0
 margin_top = 70.0
 margin_right = 572.0
 margin_bottom = 85.0
+grow_horizontal = 2
 text = "0"
 align = 1
 

--- a/scenes/Gameplay.tscn
+++ b/scenes/Gameplay.tscn
@@ -55,3 +55,10 @@ player_path = NodePath("../Player2")
 position = Vector2( 384, 15 )
 p1_path = NodePath("../Player1")
 p2_path = NodePath("../Player2")
+
+[node name="GameOverToResetDelay" type="Timer" parent="."]
+pause_mode = 2
+wait_time = 1.5
+one_shot = true
+
+[connection signal="timeout" from="GameOverToResetDelay" to="." method="_on_GameOverToResetDelay_timeout"]

--- a/scenes/Gameplay.tscn
+++ b/scenes/Gameplay.tscn
@@ -18,6 +18,17 @@ grow_horizontal = 2
 text = "0"
 align = 1
 
+[node name="Announcement" type="Label" parent="."]
+visible = false
+margin_left = 14.0
+margin_top = 89.0
+margin_right = 346.0
+margin_bottom = 104.0
+grow_horizontal = 2
+rect_scale = Vector2( 3, 3 )
+text = "Game Over"
+align = 1
+
 [node name="Player1" parent="." instance=ExtResource( 1 )]
 position = Vector2( 256, 300 )
 target_player_path = NodePath("../Player2")

--- a/scenes/Player.gd
+++ b/scenes/Player.gd
@@ -10,7 +10,7 @@ signal upgrades_changed
 
 export var speed = 125
 export var max_health = 5
-var health = max_health
+onready var health = max_health
 export var player_number = 1
 export(NodePath) var target_player_path
 

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -48,6 +48,7 @@ stream = ExtResource( 3 )
 stream = ExtResource( 6 )
 
 [node name="SFX_Explosion_Long" type="AudioStreamPlayer" parent="."]
+pause_mode = 2
 stream = ExtResource( 5 )
 
 [node name="SFX_Explosion_High" type="AudioStreamPlayer" parent="."]

--- a/scenes/RestartGameControl.gd
+++ b/scenes/RestartGameControl.gd
@@ -1,0 +1,12 @@
+extends Node
+
+var allow_reset_game = false
+
+func _input(event):
+	# Press any key to restart game after lingering on the Game Over screen.
+	if allow_reset_game && event is InputEventKey:
+		get_tree().paused = false
+		allow_reset_game = false
+
+func _on_GameOverToResetDelay_timeout():
+	allow_reset_game = true

--- a/scenes/RestartGameControl.gd
+++ b/scenes/RestartGameControl.gd
@@ -7,6 +7,7 @@ func _input(event):
 	if allow_reset_game && event is InputEventKey:
 		get_tree().paused = false
 		allow_reset_game = false
+		get_tree().reload_current_scene()
 
 func _on_GameOverToResetDelay_timeout():
 	allow_reset_game = true


### PR DESCRIPTION
Screenshot of the prompt shown before restarting. Any key includes every key, including Print Screen.
![game-over-restart_2022-10-03_12-44](https://user-images.githubusercontent.com/11843918/193643837-d4a30461-0363-4969-af20-70a8daf6edf5.png)