### PR TITLE
Documentation - Standardize Readme to Answer What, Where, How, and Who AND Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Sam Bumgardner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# power-up-ld-51
+A game originally created for the Ludum Dare 51 game jam in 72 hours.
+
+## Play the Game
+[Play on itch.io](https://nbumgardner.itch.io/ludum-dare-51-power-up)
+
+_Power Up!_ is all about head-to-head projectile-slinging mayhem. Grab your nearest friend (or enemy) and engage in an ever-escalating bullet hell battle!
+
+## How to Run Project Locally
+To run the project locally:
+
+1. Open the project with the Godot editor.
+2. Click the play button (shortcut F5) in the top-right corner.
+
+## Credits
+Team members include:
+
+- Sam Bumgardner: Artist, Game Design, Lead Programmer
+- Noah Bumgardner: Programmer, Composer
+
+### Attributions
+Coded using the [Godot](https://godotengine.org) game engine.
+
+The original game jam version, tagged as `ld51-submission` and [hosted on itch.io](https://nbumgardner.itch.io/ludum-dare-51-power-up), runs on Godot version 3.x.
+
+### License
+This game's code is open-source under the MIT License.
+Please ask the original artists before using any art or audio assets in a different context.


### PR DESCRIPTION
Standardize the readmes of GitHub repositories for Ludum Dare game jams I have contributed to.

## Implementation Details

Update the `README.md` file to mention the game name, where to play it, how to run the project, and credits. Also add the missing MIT license.